### PR TITLE
rounded values to 2 decimals in statistics

### DIFF
--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -9,7 +9,7 @@
       </tr>
       <tr v-for="(change, index) in $store.state.changes[index]" :key="index">
         <td>{{ change.field }}</td>
-        <td>{{ change.value }}</td>
+        <td>{{ change.value.toFixed(2) }}</td>
         <td v-show="change.indicator === '+'">&#x2B06;</td>
         <td v-show="change.indicator === '-'">&#x2B07;</td>
         <td>{{ change.time }}</td>


### PR DESCRIPTION
#### Type of fix:
Bug

#### Purpose of the PR :  
Rounds off values in statistics page to 2 decimals

#### Issue link :  https://github.com/SrdjanMilic/Super-Dynamic-Data/issues/10

#### Screenshots (if appropriate)
![Screenshot 2021-04-24 155523](https://user-images.githubusercontent.com/38141788/115955759-38753100-a516-11eb-9258-49d36f8e03c6.jpg)
